### PR TITLE
Country getters & corrected names of some tests

### DIFF
--- a/rxkata/src/main/java/org/sergiiz/rxkata/Country.java
+++ b/rxkata/src/main/java/org/sergiiz/rxkata/Country.java
@@ -12,6 +12,18 @@ class Country {
         this.population = population;
     }
 
+    public String getName() {
+        return name;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public long getPopulation() {
+        return population;
+    }
+
     @Override
     public String toString() {
         return "Country{" +

--- a/rxkata/src/test/java/org/sergiiz/rxkata/CountriesServiceSolvedTest.java
+++ b/rxkata/src/test/java/org/sergiiz/rxkata/CountriesServiceSolvedTest.java
@@ -122,7 +122,7 @@ public class CountriesServiceSolvedTest {
     }
 
     @Test
-    public void rx_GetCurrencyUsdIfNotFound_When_CurrencyFound() {
+    public void rx_GetCurrencyUsdIfNotFound_When_CountryFound() {
         String countryRequested = "Austria";
         String expectedCurrencyValue = "EUR";
         TestObserver<String> testObserver = countriesService
@@ -133,7 +133,7 @@ public class CountriesServiceSolvedTest {
     }
 
     @Test
-    public void rx_GetCurrencyUsdIfNotFound_When_CurrencyNotFound() {
+    public void rx_GetCurrencyUsdIfNotFound_When_CountryNotFound() {
         String countryRequested = "Senegal";
         String expectedCurrencyValue = "USD";
         TestObserver<String> testObserver = countriesService


### PR DESCRIPTION
* `*Currency*Found` should be `*Country*Found`
* added getters to the Country-class so that we can use method references (e.g. `Country::getCurrency`)
