### PR TITLE
Stop creating unnecessary threads in tests

### DIFF
--- a/rxkata/src/test/java/org/sergiiz/rxkata/CountriesServiceSolvedTest.java
+++ b/rxkata/src/test/java/org/sergiiz/rxkata/CountriesServiceSolvedTest.java
@@ -119,7 +119,6 @@ public class CountriesServiceSolvedTest {
             TimeUnit.MILLISECONDS.sleep(100);
             return allCountries;
         });
-        new Thread(futureTask).start();
         TestObserver<Country> testObserver = countriesService
                 .listPopulationMoreThanOneMillionWithTimeoutFallbackToEmpty(futureTask)
                 .test();
@@ -136,7 +135,6 @@ public class CountriesServiceSolvedTest {
             TimeUnit.HOURS.sleep(1);
             return allCountries;
         });
-        new Thread(futureTask).start();
         TestObserver<Country> testObserver = countriesService
                 .listPopulationMoreThanOneMillionWithTimeoutFallbackToEmpty(futureTask)
                 .test();


### PR DESCRIPTION
I believe this was introduced in order to force the test to wait, just in case the implementation of the method under test were to subscribe the FutureTask in a separate therad (e.g. using a Scheduler), but the call to "awaitTerminalEvent" suffices for that.